### PR TITLE
Fix corporate service links

### DIFF
--- a/src/app/Components/Home/Home.tsx
+++ b/src/app/Components/Home/Home.tsx
@@ -161,7 +161,7 @@ export default function Home() {
   {[
     { t: "Cartelería digital", d: "LED/monitores para outdoor, indoor y retail, con gestión remota de contenidos.", img: "carteleria-digital", href: "/servicios/Carteleria-digital" },
     { t: "Eventos", d: "Realización y streaming con cámaras PTZ, procesadores y mezcladores HD/4K.", img: "eventos", href: "/servicios/eventos" },
-    { t: "Corporativo", d: "Salas de reunión y coworking con videoconferencia, audio pro y reserva de salas.", img: "corporativo", href: "/servicios/corporativo" },
+    { t: "Corporativo", d: "Salas de reunión y coworking con videoconferencia, audio pro y reserva de salas.", img: "corporativo", href: "/servicios/corporativos" },
     { t: "Cultura y ocio", d: "Experiencias inmersivas en teatros, museos, discotecas y centros religiosos.", img: "cultura-ocio", href: "/servicios/cultura-y-ocio" },
     { t: "Educación", d: "Aulas interactivas: monitores táctiles, cámaras 4K y audio de alta cobertura.", img: "educacion", href: "/servicios/educacion" },
     { t: "Salas de control", d: "Videowalls para visualización en tiempo real y toma de decisiones ágil.", img: "salas-control", href: "/servicios/salas-de-control" },

--- a/src/app/Components/corporativos/corporativos.tsx
+++ b/src/app/Components/corporativos/corporativos.tsx
@@ -19,7 +19,7 @@ export default function Corporativos() {
 
   const breadcrumbs = [
     { name: "Inicio", url: "/" },
-    { name: "Soluciones corporativas", url: "/corporativo" },
+    { name: "Soluciones corporativas", url: "/servicios/corporativos" },
   ];
 
   const summary = [
@@ -86,7 +86,7 @@ export default function Corporativos() {
                 logo: brand.logo,
               },
               areaServed: "ES",
-              url: `${brand.url}corporativo`,
+              url: `${brand.url}servicios/corporativos`,
               description:
                 "Integración llave en mano de videoconferencia, audio profesional y visualización para empresas.",
             },


### PR DESCRIPTION
## Summary
- fix the home page card so it links to the corporativos service route
- update the corporativos breadcrumbs and structured data to reference the correct URL

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3b5ccb6e083269a3ad6d5bf238b56