### PR TITLE
Add breadcrumbs and hero subtitles to service pages

### DIFF
--- a/src/app/Components/carteleria-digital/carteleria-digital.css
+++ b/src/app/Components/carteleria-digital/carteleria-digital.css
@@ -102,6 +102,22 @@
   font-weight: 800; letter-spacing: -.02em; margin: 0;
   text-shadow: 0 6px 26px rgba(0,0,0,.35);
 }
+.service-hero__subtitle{
+  margin:.35rem 0 0;
+  font-size:clamp(1.1rem, 1.4vw + .7rem, 1.6rem);
+  font-weight:500;
+  color:#f3f4f6;
+  max-width:44rem;
+  text-shadow:0 4px 18px rgba(0,0,0,.35);
+}
+
+/* Breadcrumbs */
+.breadcrumbs { margin-bottom: .5rem; font-size: .875rem; color: #e5e7eb; }
+.breadcrumbs ol { display: flex; gap: .5rem; list-style: none; padding: 0; margin: 0; }
+.breadcrumbs li { display: inline-flex; align-items: center; gap: .5rem; }
+.breadcrumbs li:not(:last-child)::after { content: "/"; opacity: .7; }
+.breadcrumbs a { color: inherit; text-decoration: none; }
+.breadcrumbs a:hover { text-decoration: underline; }
 
 /* Accesibilidad / rendimiento de animaciones */
 @media (prefers-reduced-motion: reduce){

--- a/src/app/Components/carteleria-digital/carteleria-digital.tsx
+++ b/src/app/Components/carteleria-digital/carteleria-digital.tsx
@@ -43,6 +43,12 @@ export default function CarteleriaDigital() {
     },
   ];
 
+  const breadcrumbs = [
+    { name: "Inicio", url: "/" },
+    { name: "Servicios", url: "/servicios" },
+    { name: "Cartelería digital", url: "/servicios/Carteleria-digital" },
+  ];
+
   return (
     <>
       <Script
@@ -103,7 +109,20 @@ export default function CarteleriaDigital() {
           />
         </div>
         <div className="container">
-          
+          <nav className="breadcrumbs" aria-label="breadcrumbs">
+            <ol>
+              {breadcrumbs.map((b, i) => (
+                <li key={b.url}>
+                  {i < breadcrumbs.length - 1 ? (
+                    <Link href={b.url}>{b.name}</Link>
+                  ) : (
+                    <span aria-current="page">{b.name}</span>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </nav>
+
           <h1 className="service-hero__title">Cartelería digital</h1>
           <h2 className="service-hero__subtitle">
             Pantallas LED y monitores profesionales 24/7 con gestión remota.

--- a/src/app/Components/corporativos/corporativos.css
+++ b/src/app/Components/corporativos/corporativos.css
@@ -32,6 +32,14 @@
   font-weight: 800; letter-spacing:-.02em; margin:0;
   text-shadow: 0 6px 26px rgba(0,0,0,.35);
 }
+.service-hero__subtitle {
+  margin:.35rem 0 0;
+  font-size:clamp(1.1rem, 1.4vw + .7rem, 1.6rem);
+  font-weight:500;
+  color:#f3f4f6;
+  max-width:44rem;
+  text-shadow:0 4px 18px rgba(0,0,0,.35);
+}
 
 /* ===== Breadcrumbs ===== */
 .breadcrumbs { margin-bottom: .5rem; font-size: .875rem; color: #e5e7eb; }

--- a/src/app/Components/corporativos/corporativos.tsx
+++ b/src/app/Components/corporativos/corporativos.tsx
@@ -140,6 +140,9 @@ export default function Corporativos() {
           </nav>
 
           <h1 className="service-hero__title">Soluciones corporativas</h1>
+          <h2 className="service-hero__subtitle">
+            Integración audiovisual llave en mano para salas, coworkings y auditorios.
+          </h2>
         </div>
       </main>
 

--- a/src/app/Components/cultura-y-ocio/cultura-y-ocio.css
+++ b/src/app/Components/cultura-y-ocio/cultura-y-ocio.css
@@ -10,6 +10,15 @@
 }
 .service-hero .container, .service-hero__title { position:relative; z-index:2; }
 .service-hero__title { font-size: clamp(2rem, 3vw + 1rem, 3rem); font-weight:800; letter-spacing:-.02em; margin:0; text-shadow:0 6px 26px rgba(0,0,0,.35); }
+.service-hero__subtitle { margin:.35rem 0 0; font-size:clamp(1.1rem, 1.4vw + .7rem, 1.6rem); font-weight:500; color:#f3f4f6; max-width:44rem; text-shadow:0 4px 18px rgba(0,0,0,.35); }
+
+/* Breadcrumbs */
+.breadcrumbs { margin-bottom: .5rem; font-size: .875rem; color: #e5e7eb; }
+.breadcrumbs ol { display: flex; gap: .5rem; list-style: none; padding: 0; margin: 0; }
+.breadcrumbs li { display: inline-flex; align-items: center; gap: .5rem; }
+.breadcrumbs li:not(:last-child)::after { content: "/"; opacity: .7; }
+.breadcrumbs a { color: inherit; text-decoration: none; }
+.breadcrumbs a:hover { text-decoration: underline; }
 
 /* Sección y cards (idénticas a otros servicios) */
 .section { padding: clamp(2.5rem, 5vw, 4rem) 0; }

--- a/src/app/Components/cultura-y-ocio/cultura-y-ocio.tsx
+++ b/src/app/Components/cultura-y-ocio/cultura-y-ocio.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import Script from "next/script";
 import Image from "next/image";
 import { motion, useReducedMotion } from "framer-motion";
@@ -8,6 +9,12 @@ import "./cultura-y-ocio.css";
 
 export default function CulturaYOcio() {
   const reduce = useReducedMotion();
+
+  const breadcrumbs = [
+    { name: "Inicio", url: "/" },
+    { name: "Servicios", url: "/servicios" },
+    { name: "Cultura y ocio", url: "/servicios/cultura-y-ocio" },
+  ];
 
   return (
     <>
@@ -27,7 +34,7 @@ export default function CulturaYOcio() {
         }}
       />
 
-      <SiteHeader  logoAlt="logo MyL3d" />
+      <SiteHeader logoAlt="logo MyL3d" />
 
       {/* HERO optimizado con next/image */}
       <main id="service-hero" className="service-hero">
@@ -44,7 +51,24 @@ export default function CulturaYOcio() {
           />
         </div>
         <div className="container">
+          <nav className="breadcrumbs" aria-label="breadcrumbs">
+            <ol>
+              {breadcrumbs.map((b, i) => (
+                <li key={b.url}>
+                  {i < breadcrumbs.length - 1 ? (
+                    <Link href={b.url}>{b.name}</Link>
+                  ) : (
+                    <span aria-current="page">{b.name}</span>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </nav>
+
           <h1 className="service-hero__title">Cultura y ocio</h1>
+          <h2 className="service-hero__subtitle">
+            Experiencias inmersivas para museos, teatros y ocio nocturno.
+          </h2>
         </div>
       </main>
 

--- a/src/app/Components/educacion/educacion.css
+++ b/src/app/Components/educacion/educacion.css
@@ -10,6 +10,15 @@
 }
 .service-hero .container, .service-hero__title { position:relative; z-index:2; }
 .service-hero__title { font-size: clamp(2rem, 3vw + 1rem, 3rem); font-weight:800; letter-spacing:-.02em; margin:0; text-shadow:0 6px 26px rgba(0,0,0,.35); }
+.service-hero__subtitle { margin:.35rem 0 0; font-size:clamp(1.1rem, 1.4vw + .7rem, 1.6rem); font-weight:500; color:#f3f4f6; max-width:44rem; text-shadow:0 4px 18px rgba(0,0,0,.35); }
+
+/* Breadcrumbs */
+.breadcrumbs { margin-bottom: .5rem; font-size: .875rem; color: #e5e7eb; }
+.breadcrumbs ol { display: flex; gap: .5rem; list-style: none; padding: 0; margin: 0; }
+.breadcrumbs li { display: inline-flex; align-items: center; gap: .5rem; }
+.breadcrumbs li:not(:last-child)::after { content: "/"; opacity: .7; }
+.breadcrumbs a { color: inherit; text-decoration: none; }
+.breadcrumbs a:hover { text-decoration: underline; }
 
 /* Sección y CTA */
 .section { padding: clamp(2.5rem, 5vw, 4rem) 0; }

--- a/src/app/Components/educacion/educacion.tsx
+++ b/src/app/Components/educacion/educacion.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import Script from "next/script";
 import Image from "next/image";
 import { motion, useReducedMotion } from "framer-motion";
@@ -8,6 +9,12 @@ import "./educacion.css";
 
 export default function Educacion() {
   const reduce = useReducedMotion();
+
+  const breadcrumbs = [
+    { name: "Inicio", url: "/" },
+    { name: "Servicios", url: "/servicios" },
+    { name: "Educación", url: "/servicios/educacion" },
+  ];
 
   return (
     <>
@@ -27,7 +34,7 @@ export default function Educacion() {
         }}
       />
 
-      <SiteHeader  logoAlt="logo MyL3d" />
+      <SiteHeader logoAlt="logo MyL3d" />
 
       {/* HERO optimizado con next/image */}
       <main id="service-hero" className="service-hero">
@@ -44,7 +51,23 @@ export default function Educacion() {
           />
         </div>
         <div className="container">
+          <nav className="breadcrumbs" aria-label="breadcrumbs">
+            <ol>
+              {breadcrumbs.map((b, i) => (
+                <li key={b.url}>
+                  {i < breadcrumbs.length - 1 ? (
+                    <Link href={b.url}>{b.name}</Link>
+                  ) : (
+                    <span aria-current="page">{b.name}</span>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </nav>
           <h1 className="service-hero__title">Educación</h1>
+          <h2 className="service-hero__subtitle">
+            Tecnología interactiva para aulas híbridas y campus conectados.
+          </h2>
         </div>
       </main>
 

--- a/src/app/Components/eventos/eventos.css
+++ b/src/app/Components/eventos/eventos.css
@@ -10,6 +10,15 @@
 }
 .service-hero .container, .service-hero__title { position:relative; z-index:2; }
 .service-hero__title { font-size: clamp(2rem, 3vw + 1rem, 3rem); font-weight:800; letter-spacing:-.02em; margin:0; text-shadow:0 6px 26px rgba(0,0,0,.35); }
+.service-hero__subtitle { margin:.35rem 0 0; font-size:clamp(1.1rem, 1.4vw + .7rem, 1.6rem); font-weight:500; color:#f3f4f6; max-width:44rem; text-shadow:0 4px 18px rgba(0,0,0,.35); }
+
+/* Breadcrumbs */
+.breadcrumbs { margin-bottom: .5rem; font-size: .875rem; color: #e5e7eb; }
+.breadcrumbs ol { display: flex; gap: .5rem; list-style: none; padding: 0; margin: 0; }
+.breadcrumbs li { display: inline-flex; align-items: center; gap: .5rem; }
+.breadcrumbs li:not(:last-child)::after { content: "/"; opacity: .7; }
+.breadcrumbs a { color: inherit; text-decoration: none; }
+.breadcrumbs a:hover { text-decoration: underline; }
 
 /* Sección y CTA */
 .section { padding: clamp(2.5rem, 5vw, 4rem) 0; }

--- a/src/app/Components/eventos/eventos.tsx
+++ b/src/app/Components/eventos/eventos.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import Script from "next/script";
 import Image from "next/image";
 import { motion, useReducedMotion } from "framer-motion";
@@ -8,6 +9,12 @@ import "./eventos.css";
 
 export default function Eventos() {
   const reduce = useReducedMotion();
+
+  const breadcrumbs = [
+    { name: "Inicio", url: "/" },
+    { name: "Servicios", url: "/servicios" },
+    { name: "Eventos", url: "/servicios/eventos" },
+  ];
 
   // Helper por si hay espacios en el nombre del archivo
   const src = (p: string) => encodeURI(p);
@@ -64,7 +71,7 @@ export default function Eventos() {
         }}
       />
 
-      <SiteHeader  logoAlt="logo MyL3d" />
+      <SiteHeader logoAlt="logo MyL3d" />
 
       {/* HERO optimizado con next/image */}
       <main id="service-hero" className="service-hero">
@@ -81,7 +88,23 @@ export default function Eventos() {
           />
         </div>
         <div className="container">
+          <nav className="breadcrumbs" aria-label="breadcrumbs">
+            <ol>
+              {breadcrumbs.map((b, i) => (
+                <li key={b.url}>
+                  {i < breadcrumbs.length - 1 ? (
+                    <Link href={b.url}>{b.name}</Link>
+                  ) : (
+                    <span aria-current="page">{b.name}</span>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </nav>
           <h1 className="service-hero__title">Eventos</h1>
+          <h2 className="service-hero__subtitle">
+            Producción audiovisual integral para conciertos, festivales y ferias.
+          </h2>
         </div>
       </main>
 

--- a/src/app/Components/salas-de-control/salas-de-control.css
+++ b/src/app/Components/salas-de-control/salas-de-control.css
@@ -14,6 +14,22 @@
   font-weight: 800; letter-spacing:-.02em; margin:0;
   text-shadow: 0 6px 26px rgba(0,0,0,.35);
 }
+.service-hero__subtitle {
+  margin:.35rem 0 0;
+  font-size:clamp(1.1rem, 1.4vw + .7rem, 1.6rem);
+  font-weight:500;
+  color:#f3f4f6;
+  max-width:44rem;
+  text-shadow:0 4px 18px rgba(0,0,0,.35);
+}
+
+/* Breadcrumbs */
+.breadcrumbs { margin-bottom: .5rem; font-size: .875rem; color: #e5e7eb; }
+.breadcrumbs ol { display: flex; gap: .5rem; list-style: none; padding: 0; margin: 0; }
+.breadcrumbs li { display: inline-flex; align-items: center; gap: .5rem; }
+.breadcrumbs li:not(:last-child)::after { content: "/"; opacity: .7; }
+.breadcrumbs a { color: inherit; text-decoration: none; }
+.breadcrumbs a:hover { text-decoration: underline; }
 
 /* Sección y CTA */
 .section { padding: clamp(2.5rem, 5vw, 4rem) 0; }

--- a/src/app/Components/salas-de-control/salas-de-control.tsx
+++ b/src/app/Components/salas-de-control/salas-de-control.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import Script from "next/script";
 import Image from "next/image";
 import { motion, useReducedMotion } from "framer-motion";
@@ -8,6 +9,12 @@ import "./salas-de-control.css";
 
 export default function SalasDeControl() {
   const reduce = useReducedMotion();
+
+  const breadcrumbs = [
+    { name: "Inicio", url: "/" },
+    { name: "Servicios", url: "/servicios" },
+    { name: "Salas de control", url: "/servicios/salas-de-control" },
+  ];
 
   return (
     <>
@@ -27,7 +34,7 @@ export default function SalasDeControl() {
         }}
       />
 
-      <SiteHeader  logoAlt="logo MyL3d" />
+      <SiteHeader logoAlt="logo MyL3d" />
 
       {/* HERO optimizado con next/image */}
       <main id="service-hero" className="service-hero">
@@ -44,7 +51,23 @@ export default function SalasDeControl() {
           />
         </div>
         <div className="container">
+          <nav className="breadcrumbs" aria-label="breadcrumbs">
+            <ol>
+              {breadcrumbs.map((b, i) => (
+                <li key={b.url}>
+                  {i < breadcrumbs.length - 1 ? (
+                    <Link href={b.url}>{b.name}</Link>
+                  ) : (
+                    <span aria-current="page">{b.name}</span>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </nav>
           <h1 className="service-hero__title">Salas de control</h1>
+          <h2 className="service-hero__subtitle">
+            Videowalls críticos, gestión de señales y operación continua 24/7.
+          </h2>
         </div>
       </main>
 


### PR DESCRIPTION
## Summary
- add breadcrumb navigation lists and hero subtitles to every services component
- style hero subtitles and breadcrumb trails within each service CSS module for consistent presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5264ed1b08326a71ab25d36cf1827