### PR TITLE
Enhance SEO metadata and structured content

### DIFF
--- a/src/app/Components/Home/Home.css
+++ b/src/app/Components/Home/Home.css
@@ -2,7 +2,7 @@
   position: relative;
   min-height: 100vh;
   background:
-    linear-gradient(rgba(0,0,0,.85), rgba(0,0,0,.85)), /* ↑ más oscuro */
+    linear-gradient(rgba(2,6,23,.78), rgba(2,6,23,.9)),
     url("/hero.jpg") center / cover no-repeat fixed;
   isolation: isolate;
 }
@@ -45,21 +45,18 @@
 }
 .nav__links a:hover{ opacity: .85; }
 
-/* Layout del hero: título a la izquierda y CTA a la derecha */
 .hero__inner{
   min-height: 100vh;
-  padding-top: 92px; /* deja espacio bajo la navbar */
+  padding-top: 92px;
   display: grid;
-  align-items: center;
-  grid-template-columns: 1.2fr .8fr;
-  gap: clamp(1rem, 4vw, 4rem);
-
+  place-content: center;
+  gap: clamp(1.2rem, 2.5vw, 2.25rem);
 }
 .hero__title{
   margin: 0;
   font-weight: 800;
-  line-height: 1.02;
-  font-size: clamp(2.2rem, 7.8vw, 5.4rem);
+  line-height: 1.05;
+  font-size: clamp(2.4rem, 6vw, 4.2rem);
   color: var(--muted);
 }
 
@@ -69,8 +66,11 @@
 .hero__title:hover .accent{ color: #fff; }
 
 .hero__cta{
-  justify-self: end;
-  align-self: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
 }
 .btn-cta{
   display: inline-block;
@@ -87,7 +87,14 @@
   transform: translateY(-1px);
   background-color: #fff;
   color: #3001CA;
-  
+
+}
+
+.hero__subtitle{
+  margin: 1rem auto 0;
+  max-width: 60ch;
+  color: #e2e8f0;
+  font-size: clamp(1.05rem, 1.6vw, 1.35rem);
 }
 
 /* Contenedor del dropdown */

--- a/src/app/Components/Home/Home.tsx
+++ b/src/app/Components/Home/Home.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import Script from "next/script";
+import Image from "next/image";
 import { motion, type Variants } from "framer-motion";
 import SiteHeader from "@/app/Components/site-header/Siteheader";
 import Link from "next/link";
-
 
 const container: Variants = {
   hidden: { opacity: 0 },
@@ -26,7 +26,6 @@ const item: Variants = {
   },
 };
 
-// Indicador/flotante "scroll down"
 function ScrollDown() {
   return (
     <motion.a
@@ -40,7 +39,7 @@ function ScrollDown() {
       <span className="scroll-indicator__dot" />
       <span className="scroll-indicator__text">Desliza</span>
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
     </motion.a>
   );
@@ -49,170 +48,311 @@ function ScrollDown() {
 export default function Home() {
   return (
     <>
-      <Script id="ld-org" type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify({ "@context":"https://schema.org", "@type":"Organization", name:"Nombre de la marca", url:"https://www.tu-dominio.com/", logo:"https://www.tu-dominio.com/logo.png", sameAs:["https://www.instagram.com/tumarca/"] }) }}
+      <Script
+        id="home-structured-data"
+        type="application/ld+json"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@graph": [
+              {
+                "@type": "WebPage",
+                "@id": "https://www.myl3d.es/#webpage",
+                url: "https://www.myl3d.es/",
+                name: "Soluciones audiovisuales y alquiler de pantallas LED en España | MyL3d",
+                description:
+                  "MyL3d ofrece cartelería digital, alquiler de pantallas LED y producción audiovisual para eventos corporativos, retail y cultura en toda España.",
+                inLanguage: "es-ES",
+                isPartOf: { "@id": "https://www.myl3d.es/#website" },
+              },
+              {
+                "@type": "Service",
+                name: "Soluciones audiovisuales MyL3d",
+                url: "https://www.myl3d.es/",
+                provider: { "@id": "https://www.myl3d.es/#organization" },
+                areaServed: { "@type": "Country", name: "España" },
+                serviceType: [
+                  "Alquiler de pantallas LED",
+                  "Cartelería digital",
+                  "Producción audiovisual para eventos",
+                ],
+                offers: {
+                  "@type": "Offer",
+                  availability: "https://schema.org/InStock",
+                  priceSpecification: {
+                    "@type": "PriceSpecification",
+                    priceCurrency: "EUR",
+                    price: "0",
+                    description: "Presupuestos personalizados a medida de cada proyecto.",
+                  },
+                },
+              },
+            ],
+          }),
+        }}
       />
 
-      <SiteHeader logoSrc="/logo.png" logoAlt="Nombre de la marca" />
+      <SiteHeader logoSrc="/logo.png" logoAlt="MyL3d, especialistas en soluciones audiovisuales" />
 
-      {/* HERO */}
       <main id="home" className="hero">
-        <motion.section className="container hero__inner" aria-labelledby="hero-title"
-          variants={container} initial="hidden" animate="show">
+        <motion.section
+          className="container hero__inner"
+          aria-labelledby="hero-title"
+          variants={container}
+          initial="hidden"
+          animate="show"
+        >
           <motion.h1 id="hero-title" className="hero__title" variants={item}>
-            <span className="accent accent--glow">Soluciones</span> audiovisuales
+            <span className="accent accent--glow">Soluciones</span> audiovisuales integrales
           </motion.h1>
+          <motion.p className="hero__subtitle" variants={item}>
+            Diseño, alquiler e instalación de pantallas LED, cartelería digital y sistemas audiovisuales para eventos, retail y espacios corporativos en toda España.
+          </motion.p>
           <motion.div className="hero__cta" variants={item}>
-            <h2><i>Innovación visual para cada espacio</i></h2>
             <motion.a className="btn-cta sheen" href="#about" whileHover={{ y: -2, scale: 1.02 }} whileTap={{ scale: 0.98 }}>
               Más información
             </motion.a>
+            <Link className="hero__secondary" href="/contacto">
+              Solicitar presupuesto
+            </Link>
           </motion.div>
         </motion.section>
 
-        {/* Indicador de scroll */}
-        <ScrollDown />  
+        <ScrollDown />
       </main>
 
-{/* SECCIÓN: Quiénes somos */}
-<section id="about" className="section section--alt">
-  <div className="container about-grid">
-    {/* Columna texto */}
-    <div className="about-text">
-      <motion.h2
-        variants={item}
-        initial="hidden"
-        whileInView="show"
-        viewport={{ once: true, amount: 0.2 }}
-        className="section__title"
-        style={{ color: "#000" }}
-      >
-        Quiénes somos
-      </motion.h2>
+      <section id="about" className="section section--alt">
+        <div className="container about-grid">
+          <div className="about-text">
+            <motion.h2
+              variants={item}
+              initial="hidden"
+              whileInView="show"
+              viewport={{ once: true, amount: 0.2 }}
+              className="section__title"
+              style={{ color: "#000" }}
+            >
+              Quiénes somos
+            </motion.h2>
 
-      <motion.div
-        variants={item}
-        initial="hidden"
-        whileInView="show"
-        viewport={{ once: true, amount: 0.2 }}
-        className="section__copy"
-      >
-        <p>
-          En <strong>MyL3d</strong> somos especialistas en
-          <strong> soluciones audiovisuales llave en mano</strong> para empresas, marcas e instituciones
-          que buscan generar impacto en sus <strong>eventos corporativos, conferencias, ferias y presentaciones</strong>.
-          </p>
+            <motion.div
+              variants={item}
+              initial="hidden"
+              whileInView="show"
+              viewport={{ once: true, amount: 0.2 }}
+              className="section__copy"
+            >
+              <p>
+                En <strong>MyL3d</strong> diseñamos e implantamos <strong>soluciones audiovisuales llave en mano</strong> para empresas, instituciones y marcas que buscan experiencias memorables en ferias, congresos y retail.
+              </p>
+              <p>
+                Nuestro equipo acompaña cada proyecto desde el <strong>asesoramiento técnico</strong> y la ingeniería previa hasta la instalación, operación en directo y soporte post evento.
+              </p>
+              <p>
+                Apostamos por la innovación y la fiabilidad para crear <strong>entornos inmersivos</strong> que refuercen la identidad de tu marca. Descubre nuestras propuestas de
+                {" "}
+                <Link href="/servicios/eventos">producción audiovisual para eventos</Link>,
+                {" "}
+                <Link href="/servicios/corporativos">salas corporativas</Link>
+                {" "}y
+                {" "}
+                <Link href="/servicios/cultura-y-ocio">espacios culturales y de ocio</Link>.
+              </p>
+            </motion.div>
+          </div>
 
+          <div className="about-image">
+            <Image
+              src="/about.png"
+              alt="Equipo técnico de MyL3d instalando pantallas LED"
+              width={720}
+              height={480}
+              priority
+              className="about-image__media"
+            />
+          </div>
+        </div>
+      </section>
 
-                <p>
-          Gracias a nuestra experiencia en el sector audiovisual, acompañamos a cada cliente en todo el proceso:
-          desde el <strong>asesoramiento inicial</strong> y el <strong>diseño de la propuesta técnica</strong>,
-          hasta la instalación, operación en el evento y soporte postventa.</p>
-          <p>
-          Nos adaptamos a tus necesidades para crear <strong>experiencias visuales memorables</strong>
-          que refuercen la identidad de tu marca y capten la atención de tu público.
-        </p>
-
-                <p>
-          Si buscas una empresa de confianza para la
-          <strong>producción audiovisual de tu evento</strong>, en <strong>MyL3d</strong> encontrarás un equipo comprometido con
-          la innovación, la puntualidad y la excelencia.
-        </p>
-
-
-
-      </motion.div>
-    </div>{/* <-- cierre about-text */}
-
-    {/* Columna imagen (hermana de about-text) */}
-    <div className="about-image">
-      <img src="/about.png" alt="Equipo trabajando en soluciones audiovisuales" />
-    </div>
-  </div>{/* <-- cierre container */}
-</section>
-
-
-<style jsx global>{`
-  .about-grid { display: grid; grid-template-columns: 1fr; gap: 2rem; align-items: center; }
-  .about-text { order: 1; }
-  .about-image { order: 2; }
-  .about-image img { width: 100%; height: auto; border-radius: 12px; }
-  @media(min-width: 768px){
-    .about-grid { grid-template-columns: 1fr 1fr; }
-    .about-text { order: 1; }
-    .about-image { order: 2; }
-  }
-`}</style>
-
-      {/* SECCIÓN: Servicios */}
       <section id="services" className="section">
         <div className="container">
           <motion.h2 variants={item} initial="hidden" whileInView="show" viewport={{ once: true, amount: 0.2 }} className="section__title">
             Servicios
           </motion.h2>
           <p>
-          Nuestro objetivo es ofrecer <strong>tecnología audiovisual de vanguardia</strong>,
-          fácil de usar, confiable y con un acabado 100% profesional,
-          para que puedas centrarte en tu mensaje mientras nosotros nos ocupamos de la parte técnica.
-        </p>
+            Nuestro objetivo es ofrecer <strong>tecnología audiovisual de vanguardia</strong>, fácil de usar, confiable y con un acabado 100% profesional para que puedas centrarte en tu mensaje mientras nosotros nos ocupamos de la parte técnica.
+          </p>
+          <p>
+            Ponemos a tu disposición un amplio catálogo de servicios audiovisuales que incluye <Link href="/servicios/Carteleria-digital">cartelería digital</Link>,
+            {" "}
+            <Link href="/servicios/eventos">realización y streaming para eventos corporativos</Link>, aulas híbridas para educación y videowalls para salas de control.
+          </p>
 
-        <p>Ponemos a tu disposición un amplio catálogo de servicios audiovisuales que incluye:</p>
-<div className="cards">
-  {[
-    { t: "Cartelería digital", d: "LED/monitores para outdoor, indoor y retail, con gestión remota de contenidos.", img: "carteleria-digital", href: "/servicios/Carteleria-digital" },
-    { t: "Eventos", d: "Realización y streaming con cámaras PTZ, procesadores y mezcladores HD/4K.", img: "eventos", href: "/servicios/eventos" },
-    { t: "Corporativo", d: "Salas de reunión y coworking con videoconferencia, audio pro y reserva de salas.", img: "corporativo", href: "/servicios/corporativos" },
-    { t: "Cultura y ocio", d: "Experiencias inmersivas en teatros, museos, discotecas y centros religiosos.", img: "cultura-ocio", href: "/servicios/cultura-y-ocio" },
-    { t: "Educación", d: "Aulas interactivas: monitores táctiles, cámaras 4K y audio de alta cobertura.", img: "educacion", href: "/servicios/educacion" },
-    { t: "Salas de control", d: "Videowalls para visualización en tiempo real y toma de decisiones ágil.", img: "salas-control", href: "/servicios/salas-de-control" },
-  ].map((c, i) => (
-    <motion.article
-      key={c.t}
-      className="card"
-      initial={{ opacity: 0, y: 16 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
-      transition={{ duration: 0.5, delay: 0.08 * i }}
-    >
-      <Link href={c.href} className="card-link">
-        <h3>{c.t}</h3>
-        <p>{c.d}</p>
-      </Link>
-    </motion.article>
-  ))}
-</div>
+          <div className="cards">
+            {[
+              {
+                t: "Cartelería digital",
+                d: "LED/monitores para outdoor, indoor y retail con gestión remota de contenidos.",
+                href: "/servicios/Carteleria-digital",
+              },
+              {
+                t: "Eventos",
+                d: "Realización y streaming con cámaras PTZ, procesadores y mezcladores HD/4K.",
+                href: "/servicios/eventos",
+              },
+              {
+                t: "Corporativo",
+                d: "Salas de reunión, coworking y auditorios con videoconferencia y audio profesional.",
+                href: "/servicios/corporativos",
+              },
+              {
+                t: "Cultura y ocio",
+                d: "Experiencias inmersivas en teatros, museos, discotecas y centros culturales.",
+                href: "/servicios/cultura-y-ocio",
+              },
+              {
+                t: "Educación",
+                d: "Aulas interactivas con monitores táctiles, cámaras 4K y audio de alta cobertura.",
+                href: "/servicios/educacion",
+              },
+              {
+                t: "Salas de control",
+                d: "Videowalls y sistemas de visualización en tiempo real para operaciones críticas.",
+                href: "/servicios/salas-de-control",
+              },
+            ].map((card, index) => (
+              <motion.article
+                key={card.t}
+                className="card"
+                initial={{ opacity: 0, y: 16 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.5, delay: 0.08 * index }}
+              >
+                <Link href={card.href} className="card-link">
+                  <h3>{card.t}</h3>
+                  <p>{card.d}</p>
+                </Link>
+              </motion.article>
+            ))}
+          </div>
         </div>
       </section>
 
-      {/* Estilos mínimos + scroll suave */}
+      <section id="solutions" className="section section--alt">
+        <div className="container">
+          <motion.h2
+            className="section__title"
+            style={{ color: "#000" }}
+            variants={item}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.2 }}
+          >
+            ¿Por qué MyL3d?
+          </motion.h2>
+          <motion.p
+            className="section__copy"
+            variants={item}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.2 }}
+          >
+            Somos especialistas en <strong>alquiler de pantallas LED en España</strong>, integración de sistemas audiovisuales y <strong>señalización digital</strong> para marcas que buscan destacar. Trabajamos proyectos llave en mano: diseño técnico, instalación, operación en directo y soporte posterior.
+          </motion.p>
+
+          <div className="value-grid" role="list">
+            {[
+              {
+                title: "Equipo experto",
+                description: "Ingenieros y técnicos con experiencia en eventos corporativos, ferias, retail y espectáculos en vivo.",
+              },
+              {
+                title: "Tecnología a medida",
+                description: "Seleccionamos pantallas LED, procesadores y sonido profesional adaptado a cada espacio y presupuesto.",
+              },
+              {
+                title: "Cobertura nacional",
+                description: "Prestamos servicio en las principales ciudades de España con logística y montaje rápido.",
+              },
+            ].map((value) => (
+              <motion.article
+                key={value.title}
+                className="value-card"
+                role="listitem"
+                variants={item}
+                initial="hidden"
+                whileInView="show"
+                viewport={{ once: true, amount: 0.2 }}
+              >
+                <h3>{value.title}</h3>
+                <p>{value.description}</p>
+              </motion.article>
+            ))}
+          </div>
+
+          <motion.p
+            className="section__copy"
+            style={{ marginTop: "1.5rem" }}
+            variants={item}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.2 }}
+          >
+            ¿Necesitas asesoramiento? <Link href="/contacto">Contacta con nuestro equipo</Link> para recibir un presupuesto personalizado y descubrir cómo potenciar tu próxima acción con audiovisuales profesionales.
+          </motion.p>
+        </div>
+      </section>
+
       <style jsx global>{`
         html { scroll-behavior: smooth; }
         .container { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; }
         .hero { position: relative; min-height: 82vh; display: grid; place-items: center; padding: 5rem 0 6rem; }
+        .hero__inner { text-align: center; }
+        .hero__title { font-size: clamp(2.2rem, 3vw + 1rem, 3.5rem); line-height: 1.1; }
+        .hero__subtitle { margin: 1rem auto 1.5rem; max-width: 65ch; font-size: clamp(1.05rem, 1.4vw + 1rem, 1.35rem); color: #e2e8f0; }
+        .hero__cta { display: flex; flex-direction: column; gap: 0.75rem; align-items: center; }
+        .hero__secondary { color: #e2e8f0; text-decoration: underline; font-weight: 500; }
         .section { padding: 5rem 0; }
         .section--alt { background: #fff; }
         .section__title { font-size: clamp(1.6rem, 2vw + 1rem, 2.25rem); margin-bottom: 0.75rem; }
-        .section__copy { color: #000000ff; max-width: 70ch; }
-        .cards {
-  display: grid;
-  gap: 1rem;
-  margin-top: 1rem;
-}
+        .section__copy { color: #0f172a; max-width: 70ch; }
 
-@media (min-width: 640px) {
-  .cards { grid-template-columns: repeat(2, 1fr); }
-}
+        .about-grid { display: grid; grid-template-columns: 1fr; gap: 2rem; align-items: center; }
+        .about-image__media { width: 100%; height: auto; border-radius: 12px; object-fit: cover; }
 
-@media (min-width: 1024px) {
-  .cards { grid-template-columns: repeat(3, 1fr); }
-}
-        .card { border: 1px solid #e5e7eb; border-radius: 14px; padding: 1rem; background: #000000ff; }
+        .cards { display: grid; gap: 1rem; margin-top: 1.25rem; }
+        .card { border: 1px solid #1e293b; border-radius: 14px; padding: 1.25rem; background: #020617; min-height: 170px; }
+        .card-link { color: #f8fafc; text-decoration: none; display: block; height: 100%; }
+        .card-link h3 { font-size: 1.15rem; margin-bottom: 0.4rem; }
+        .card-link:hover,
+        .card-link:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(48, 1, 202, 0.35); border-radius: 12px; }
 
-        /* Indicador de scroll */
-        .scroll-indicator { position: absolute; left: 50%; bottom: 1.75rem; transform: translateX(-50%); display: inline-flex; align-items: center; gap: .5rem; color: #111827; text-decoration: none; font-weight: 500; }
-        .scroll-indicator__dot { width: 8px; height: 8px; border-radius: 999px; background: #3001CA; box-shadow: 0 0 0 6px rgba(48,1,202,.12); }
-        .scroll-indicator__text { font-size: .95rem; }
-        .scroll-indicator:hover { filter: brightness(0.9); }
+        .value-grid { display: grid; gap: 1.25rem; margin-top: 1.5rem; }
+        .value-card { background: #ffffff; border-radius: 16px; border: 1px solid #e5e7eb; padding: 1.5rem; box-shadow: 0 12px 30px -22px rgba(15, 23, 42, 0.75); color: #0f172a; }
+        .value-card h3 { font-size: 1.2rem; margin-bottom: 0.5rem; }
+        .value-card p { margin: 0; }
+
+        .scroll-indicator { position: absolute; left: 50%; bottom: 1.75rem; transform: translateX(-50%); display: inline-flex; align-items: center; gap: 0.5rem; color: #e2e8f0; text-decoration: none; font-weight: 500; }
+        .scroll-indicator__dot { width: 8px; height: 8px; border-radius: 999px; background: #3001CA; box-shadow: 0 0 0 6px rgba(48, 1, 202, 0.12); }
+        .scroll-indicator__text { font-size: 0.95rem; }
+        .scroll-indicator:hover { filter: brightness(1.1); }
+
+        @media (min-width: 640px) {
+          .cards { grid-template-columns: repeat(2, 1fr); }
+        }
+
+        @media (min-width: 768px) {
+          .about-grid { grid-template-columns: 1.05fr 0.95fr; }
+          .hero__cta { flex-direction: row; }
+          .hero__cta { gap: 1rem; }
+          .value-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+        }
+
+        @media (min-width: 1024px) {
+          .cards { grid-template-columns: repeat(3, 1fr); }
+        }
       `}</style>
     </>
   );

--- a/src/app/Components/carteleria-digital/carteleria-digital.tsx
+++ b/src/app/Components/carteleria-digital/carteleria-digital.tsx
@@ -10,6 +10,8 @@ import "./carteleria-digital.css";
 export default function CarteleriaDigital() {
   const reduce = useReducedMotion();
 
+  const siteUrl = "https://www.myl3d.es";
+
   const cards = [
     {
       t: "Outdoor",
@@ -19,7 +21,7 @@ export default function CarteleriaDigital() {
         </>
       ),
       bg: "/res/tótems.png",
-      alt: "Pantallas exteriores",
+      alt: "Pantallas LED exteriores de gran formato",
     },
     {
       t: "Indoor",
@@ -29,7 +31,7 @@ export default function CarteleriaDigital() {
         </>
       ),
       bg: "/res/interior totem.png",
-      alt: "Señalización interior",
+      alt: "Sistema de señalización digital interior",
     },
     {
       t: "Retail",
@@ -39,7 +41,7 @@ export default function CarteleriaDigital() {
         </>
       ),
       bg: "/res/Portada.png",
-      alt: "Digital signage retail",
+      alt: "Pantalla de cartelería digital en retail",
     },
   ];
 
@@ -61,30 +63,38 @@ export default function CarteleriaDigital() {
             "@graph": [
               {
                 "@type": "Organization",
-                name: "MyL3D",
-                url: "https://www.myl3d.es/",
-                logo: "https://www.myl3d.es/logo.png",
+                "@id": `${siteUrl}/#organization`,
+                name: "MyL3d",
+                url: `${siteUrl}/`,
+                logo: `${siteUrl}/logo.png`,
                 sameAs: ["https://www.instagram.com/myl3d/"],
               },
               {
                 "@type": "BreadcrumbList",
-                itemListElement: [
-                  { "@type": "ListItem", position: 1, name: "Inicio", item: "https://www.tu-dominio.com/" },
-                  { "@type": "ListItem", position: 2, name: "Servicios", item: "https://www.tu-dominio.com/servicios" },
-                  { "@type": "ListItem", position: 3, name: "Cartelería digital", item: "https://www.tu-dominio.com/carteleria-digital" },
-                ],
+                itemListElement: breadcrumbs.map((crumb, index) => ({
+                  "@type": "ListItem",
+                  position: index + 1,
+                  name: crumb.name,
+                  item: `${siteUrl}${crumb.url === "/" ? "" : crumb.url}`,
+                })),
               },
               {
                 "@type": "Service",
                 name: "Cartelería digital",
-                serviceType: "MyL3d",
-                provider: { "@type": "Organization", name: "Nombre de la marca" },
+                serviceType: "Cartelería digital y pantallas LED",
+                provider: { "@id": `${siteUrl}/#organization` },
                 areaServed: { "@type": "Country", name: "España" },
                 description:
-                  "Diseñamos, instalamos e integramos cartelería digital para exteriores, interiores y retail: pantallas LED y monitores profesionales 24/7, con gestión de contenidos remota y centralizada.",
+                  "Diseñamos, instalamos e integramos cartelería digital para exteriores, interiores y retail: pantallas LED y monitores profesionales 24/7 con gestión de contenidos remota.",
                 offers: {
                   "@type": "Offer",
                   availability: "https://schema.org/InStock",
+                  priceSpecification: {
+                    "@type": "PriceSpecification",
+                    priceCurrency: "EUR",
+                    price: "0",
+                    description: "Presupuesto personalizado según las necesidades de cada espacio.",
+                  },
                 },
               },
             ],
@@ -92,13 +102,13 @@ export default function CarteleriaDigital() {
         }}
       />
 
-      <SiteHeader logoAlt="Nombre de la marca" />
+      <SiteHeader logoAlt="MyL3d" />
 
       <main id="service-hero" className="service-hero">
         <div className="service-hero__bg" aria-hidden>
           <Image
             src="/hero.jpg"
-            alt=""
+            alt="Instalación de pantallas LED para cartelería digital"
             fill
             priority
             sizes="100vw"
@@ -152,7 +162,7 @@ export default function CarteleriaDigital() {
                   <div className="cd-card__bg" aria-hidden>
                     <Image
                       src={c.bg}
-                      alt=""
+                      alt={c.alt}
                       fill
                       sizes="(min-width: 768px) 33vw, 100vw"
                       priority={i === 0}

--- a/src/app/Components/corporativos/corporativos.tsx
+++ b/src/app/Components/corporativos/corporativos.tsx
@@ -112,7 +112,7 @@
           <div className="service-hero__bg" aria-hidden="true">
             <Image
               src="/hero.jpg"
-              alt="" /* decorativo */
+              alt="Sala de reuniones corporativa equipada con pantallas LED"
               fill
               priority
               sizes="(max-width: 768px) 100vw, 100vw"

--- a/src/app/Components/cultura-y-ocio/cultura-y-ocio.tsx
+++ b/src/app/Components/cultura-y-ocio/cultura-y-ocio.tsx
@@ -92,7 +92,7 @@ export default function CulturaYOcio() {
         <div className="service-hero__bg" aria-hidden>
           <Image
             src="/hero.jpg"
-            alt=""
+            alt="Instalación audiovisual para espacios culturales"
             fill
             priority
             sizes="100vw"

--- a/src/app/Components/educacion/educacion.tsx
+++ b/src/app/Components/educacion/educacion.tsx
@@ -41,7 +41,7 @@ export default function Educacion() {
         <div className="service-hero__bg" aria-hidden>
           <Image
             src="/hero.jpg"         /* pon tu imagen */
-            alt=""
+            alt="Aula híbrida equipada con tecnología interactiva"
             fill
             priority
             sizes="100vw"

--- a/src/app/Components/eventos/eventos.tsx
+++ b/src/app/Components/eventos/eventos.tsx
@@ -78,7 +78,7 @@ export default function Eventos() {
         <div className="service-hero__bg" aria-hidden>
           <Image
             src="/hero.jpg"
-            alt=""
+            alt="Producción audiovisual en escenario para eventos"
             fill
             priority
             sizes="100vw"

--- a/src/app/Components/salas-de-control/salas-de-control.tsx
+++ b/src/app/Components/salas-de-control/salas-de-control.tsx
@@ -41,7 +41,7 @@ export default function SalasDeControl() {
         <div className="service-hero__bg" aria-hidden>
           <Image
             src="/hero.jpg"    /* tu imagen de hero */
-            alt=""
+            alt="Videowall y puestos de operador en sala de control"
             fill
             priority
             sizes="100vw"

--- a/src/app/contacto/page.tsx
+++ b/src/app/contacto/page.tsx
@@ -1,5 +1,20 @@
+import type { Metadata } from "next";
 import Contact from "../Components/contact/Contact";
 import SiteHeader from "../Components/site-header/Siteheader";
+
+export const metadata: Metadata = {
+  title: "Contacto | MyL3d",
+  description:
+    "Solicita presupuesto para pantallas LED, cartelería digital o soluciones audiovisuales integrales. Atención de lunes a viernes de 9:00 a 18:00.",
+  alternates: { canonical: "/contacto" },
+  openGraph: {
+    title: "Contacto | MyL3d",
+    description:
+      "Contacta con MyL3d para asesoramiento en alquiler de pantallas LED y producción audiovisual en España.",
+    url: "https://www.myl3d.es/contacto",
+    type: "website",
+  },
+};
 
 export default function ContactPage() {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import { SpeedInsights } from "@vercel/speed-insights/next"; // 👈 Importa aquí
 import "./globals.css";
 import "./Components/Home/Home.css";
@@ -9,28 +10,38 @@ const inter = Inter({ subsets: ["latin"] });
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.myl3d.es"),
   title: {
-    default: "MyL3d",
-    template: "%s | Nombre de la marca",
+    default: "MyL3d | Soluciones audiovisuales",
+    template: "%s | MyL3d",
   },
   description:
-    "Innovación visual para cada espacio: pantallas LED, rótulos y soluciones de señalización para comercios y eventos.",
+    "Soluciones audiovisuales llave en mano, alquiler de pantallas LED y cartelería digital para eventos, retail y espacios corporativos en toda España.",
+  keywords: [
+    "alquiler de pantallas LED",
+    "cartelería digital",
+    "producción audiovisual",
+    "soluciones audiovisuales",
+    "España",
+  ],
   alternates: { canonical: "/" },
   openGraph: {
     type: "website",
     url: "https://www.myl3d.es/",
-    title: "Innovación visual para cada espacio",
+    title: "MyL3d | Soluciones audiovisuales",
     description:
-      "Pantallas LED, rótulos y señalización digital para comercios y eventos.",
+      "Instalación y alquiler de pantallas LED, rótulos digitales y equipamiento audiovisual profesional para eventos y comercios en España.",
+    siteName: "MyL3d",
+    locale: "es_ES",
     images: [
-      { url: "/og.jpg", width: 1200, height: 630, alt: "Proyecto en vía pública" },
+      { url: "/og.jpg", width: 1200, height: 630, alt: "Instalación de pantallas LED de MyL3d" },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Innovación visual para cada espacio",
+    title: "MyL3d | Soluciones audiovisuales",
     description:
-      "Pantallas LED, rótulos y señalización digital para comercios y eventos.",
+      "Servicios audiovisuales profesionales: pantallas LED, cartelería digital y soporte técnico para eventos y retail.",
     images: ["/og.jpg"],
+    creator: "@myl3d",
   },
   robots: { index: true, follow: true },
   icons: { icon: "/favicon.ico" },
@@ -40,6 +51,81 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="es">
       <body className={inter.className}>
+        <Script
+          id="global-structured-data"
+          type="application/ld+json"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@graph": [
+                {
+                  "@type": "WebSite",
+                  "@id": "https://www.myl3d.es/#website",
+                  url: "https://www.myl3d.es/",
+                  name: "MyL3d",
+                  description:
+                    "Soluciones audiovisuales llave en mano, alquiler de pantallas LED y cartelería digital para eventos y retail en España.",
+                  inLanguage: "es-ES",
+                  publisher: { "@id": "https://www.myl3d.es/#organization" },
+                  potentialAction: {
+                    "@type": "SearchAction",
+                    target: "https://www.myl3d.es/?s={search_term_string}",
+                    "query-input": "required name=search_term_string",
+                  },
+                },
+                {
+                  "@type": "Organization",
+                  "@id": "https://www.myl3d.es/#organization",
+                  name: "MyL3d",
+                  url: "https://www.myl3d.es/",
+                  logo: "https://www.myl3d.es/logo.png",
+                  sameAs: ["https://www.instagram.com/myl3d/"],
+                  contactPoint: [
+                    {
+                      "@type": "ContactPoint",
+                      telephone: "+34 692 903 572",
+                      contactType: "customer service",
+                      areaServed: "ES",
+                      availableLanguage: ["es"],
+                    },
+                  ],
+                },
+                {
+                  "@type": "LocalBusiness",
+                  "@id": "https://www.myl3d.es/#localbusiness",
+                  name: "MyL3d",
+                  url: "https://www.myl3d.es/",
+                  image: "https://www.myl3d.es/og.jpg",
+                  email: "info@myl3d.es",
+                  telephone: "+34 692 903 572",
+                  priceRange: "€€",
+                  address: {
+                    "@type": "PostalAddress",
+                    addressCountry: "ES",
+                  },
+                  areaServed: [{ "@type": "Country", name: "España" }],
+                  openingHoursSpecification: [
+                    {
+                      "@type": "OpeningHoursSpecification",
+                      dayOfWeek: [
+                        "Monday",
+                        "Tuesday",
+                        "Wednesday",
+                        "Thursday",
+                        "Friday",
+                      ],
+                      opens: "09:00",
+                      closes: "18:00",
+                    },
+                  ],
+                  sameAs: ["https://www.instagram.com/myl3d/"],
+                  parentOrganization: { "@id": "https://www.myl3d.es/#organization" },
+                },
+              ],
+            }),
+          }}
+        />
         {children}
         <SpeedInsights /> {/* 👈 Ya está disponible en toda la app */}
       </body>

--- a/src/app/servicios/Carteleria-digital/page.tsx
+++ b/src/app/servicios/Carteleria-digital/page.tsx
@@ -1,5 +1,20 @@
+import type { Metadata } from "next";
 import CarteleriaDigital from "@/app/Components/carteleria-digital/carteleria-digital";
 import SiteHeader from "../../Components/site-header/Siteheader";
+
+export const metadata: Metadata = {
+  title: "Cartelería digital | MyL3d",
+  description:
+    "Cartelería digital y pantallas LED para exterior e interior con gestión remota de contenidos, instalación llave en mano y soporte técnico en toda España.",
+  alternates: { canonical: "/servicios/Carteleria-digital" },
+  openGraph: {
+    title: "Cartelería digital | MyL3d",
+    description:
+      "Diseño e instalación de pantallas LED y monitores profesionales 24/7 para retail, corporate y espacios públicos.",
+    url: "https://www.myl3d.es/servicios/Carteleria-digital",
+    type: "article",
+  },
+};
 
 export default function CarteleriaDigitalPage() {
   return (

--- a/src/app/servicios/corporativos/page.tsx
+++ b/src/app/servicios/corporativos/page.tsx
@@ -1,5 +1,20 @@
+import type { Metadata } from "next";
 import SiteHeader from "../../Components/site-header/Siteheader";
 import Corporativos from "@/app/Components/corporativos/corporativos";
+
+export const metadata: Metadata = {
+  title: "Soluciones audiovisuales corporativas | MyL3d",
+  description:
+    "Integración de salas de reunión, coworking y auditorios con videoconferencia, audio profesional y visualización para empresas en España.",
+  alternates: { canonical: "/servicios/corporativos" },
+  openGraph: {
+    title: "Soluciones audiovisuales corporativas | MyL3d",
+    description:
+      "Videoconferencia, audio y pantallas profesionales llave en mano para espacios corporativos.",
+    url: "https://www.myl3d.es/servicios/corporativos",
+    type: "article",
+  },
+};
 export default function ContactPage() {
   return (
     <>

--- a/src/app/servicios/cultura-y-ocio/page.tsx
+++ b/src/app/servicios/cultura-y-ocio/page.tsx
@@ -1,5 +1,20 @@
+import type { Metadata } from "next";
 import SiteHeader from "../../Components/site-header/Siteheader";
 import CulturaYOcio from "@/app/Components/cultura-y-ocio/cultura-y-ocio";
+
+export const metadata: Metadata = {
+  title: "Audiovisuales para cultura y ocio | MyL3d",
+  description:
+    "Experiencias inmersivas con pantallas LED, proyección y señalización digital para museos, teatros y ocio nocturno en España.",
+  alternates: { canonical: "/servicios/cultura-y-ocio" },
+  openGraph: {
+    title: "Audiovisuales para cultura y ocio | MyL3d",
+    description:
+      "Diseño de instalaciones audiovisuales para museos, teatros y discotecas con contenidos interactivos.",
+    url: "https://www.myl3d.es/servicios/cultura-y-ocio",
+    type: "article",
+  },
+};
 export default function ContactPage() {
   return (
     <>

--- a/src/app/servicios/educacion/page.tsx
+++ b/src/app/servicios/educacion/page.tsx
@@ -1,5 +1,20 @@
+import type { Metadata } from "next";
 import SiteHeader from "../../Components/site-header/Siteheader";
 import Educacion from "@/app/Components/educacion/educacion";
+
+export const metadata: Metadata = {
+  title: "Audiovisuales para educación | MyL3d",
+  description:
+    "Aulas híbridas, monitores táctiles, cámaras 4K y audio profesional para centros educativos y universidades en España.",
+  alternates: { canonical: "/servicios/educacion" },
+  openGraph: {
+    title: "Audiovisuales para educación | MyL3d",
+    description:
+      "Integración de tecnología interactiva y sistemas audiovisuales para aulas conectadas y campus multi-sede.",
+    url: "https://www.myl3d.es/servicios/educacion",
+    type: "article",
+  },
+};
 export default function EducacionPage() {
   return (
     <>

--- a/src/app/servicios/eventos/page.tsx
+++ b/src/app/servicios/eventos/page.tsx
@@ -1,5 +1,20 @@
+import type { Metadata } from "next";
 import SiteHeader from "../../Components/site-header/Siteheader";
 import Eventos from "@/app/Components/eventos/eventos";
+
+export const metadata: Metadata = {
+  title: "Producción audiovisual para eventos | MyL3d",
+  description:
+    "Realización multicámara, streaming y alquiler de pantallas LED para conciertos, festivales y eventos corporativos en España.",
+  alternates: { canonical: "/servicios/eventos" },
+  openGraph: {
+    title: "Producción audiovisual para eventos | MyL3d",
+    description:
+      "Servicios técnicos llave en mano: cámaras PTZ, mezcladores HD/4K, gestión de señales y soporte en directo.",
+    url: "https://www.myl3d.es/servicios/eventos",
+    type: "article",
+  },
+};
 export default function ContactPage() {
   return (
     <>

--- a/src/app/servicios/salas-de-control/page.tsx
+++ b/src/app/servicios/salas-de-control/page.tsx
@@ -1,5 +1,20 @@
+import type { Metadata } from "next";
 import SiteHeader from "../../Components/site-header/Siteheader";
 import SalasDeControl from "@/app/Components/salas-de-control/salas-de-control";
+
+export const metadata: Metadata = {
+  title: "Salas de control y videowalls | MyL3d",
+  description:
+    "Diseño de videowalls, gestión de señales y puestos de operador para salas de control 24/7 en empresas e instituciones.",
+  alternates: { canonical: "/servicios/salas-de-control" },
+  openGraph: {
+    title: "Salas de control y videowalls | MyL3d",
+    description:
+      "Integración llave en mano de videowalls, controladores y sistemas de monitorización crítica.",
+    url: "https://www.myl3d.es/servicios/salas-de-control",
+    type: "article",
+  },
+};
 export default function ContactPage() {
   return (
     <>


### PR DESCRIPTION
## Summary
- refresh the homepage hero, service descriptions, and add a value proposition section with internal links and JSON-LD service data
- inject global structured data for the brand, website, and local business along with upgraded imagery handling and styling tweaks
- add descriptive metadata, canonical alternates, and image alt text updates across contact and service routes, plus clean cartelería JSON-LD

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da999b75048326825312c171023752