### PR TITLE
Add dedicated blog resources page and navigation link

### DIFF
--- a/src/app/Components/Home/Home.css
+++ b/src/app/Components/Home/Home.css
@@ -20,6 +20,7 @@ img{ max-width:100%; display:block; }
 .section--alt { background: #fff; color: var(--ink); }
 .section__title { font-size: clamp(1.6rem, 2vw + 1rem, 2.25rem); margin: 0 0 .75rem; }
 .section__copy { color: var(--ink); }
+.section__copy--muted { color: rgba(226, 232, 240, 0.82); max-width: 65ch; }
 
 /* Enlaces utilitarios */
 .link-servicios{ text-decoration: none; color: var(--brand); }
@@ -193,6 +194,121 @@ img{ max-width:100%; display:block; }
 .value-card h3{ font-size: 1.2rem; margin: 0 0 .5rem; }
 .value-card p{ margin: 0; }
 
+/* ========== Blog preview ========== */
+.blog-grid{
+  margin-top: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.blog-card{
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 16px;
+  padding: 1.75rem;
+  position: relative;
+  overflow: hidden;
+  transition: transform .22s ease, box-shadow .22s ease, border-color .22s ease;
+}
+
+.blog-card:focus-visible{
+  outline: 3px solid rgba(48, 1, 202, 0.65);
+  outline-offset: 3px;
+}
+
+.blog-card:hover{
+  transform: translateY(-4px);
+  box-shadow: 0 25px 45px -30px rgba(15, 23, 42, 0.95);
+  border-color: rgba(99, 102, 241, 0.65);
+}
+
+.blog-card__meta{
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  font-size: .95rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.blog-card__badge{
+  display: inline-flex;
+  align-items: center;
+  padding: .3rem .75rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.18);
+  color: #c7d2fe;
+  font-size: .82rem;
+  font-weight: 600;
+  letter-spacing: .15px;
+  text-transform: uppercase;
+}
+
+.blog-card__title{
+  margin: 1.1rem 0 .6rem;
+  font-size: clamp(1.25rem, 1.8vw, 1.5rem);
+  color: #f8fafc;
+  line-height: 1.3;
+}
+
+.blog-card__excerpt{
+  margin: 0 0 1.25rem;
+  color: rgba(226, 232, 240, 0.78);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.blog-card__cta{
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  color: #c7d2fe;
+  font-weight: 600;
+  letter-spacing: .2px;
+}
+
+.blog-card__cta svg{
+  transition: transform .18s ease;
+}
+
+.blog-card:hover .blog-card__cta svg{
+  transform: translateX(4px);
+}
+
+.blog-more{
+  margin-top: 2.25rem;
+}
+
+.blog-more__link{
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  padding: .85rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  color: #c7d2fe;
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: .2px;
+  transition: transform .18s ease, background-color .18s ease, color .18s ease;
+}
+
+.blog-more__link svg{
+  transition: transform .18s ease;
+}
+
+.blog-more__link:hover{
+  transform: translateY(-2px);
+  background: rgba(99, 102, 241, 0.16);
+}
+
+.blog-more__link:hover svg{
+  transform: translateX(4px);
+}
+
 /* ========== Toggle móvil ========== */
 .nav__toggle{
   display: none;
@@ -207,6 +323,7 @@ img{ max-width:100%; display:block; }
 /* Grids responsivas por anchura */
 @media (min-width: 640px){
   .cards{ grid-template-columns: repeat(2, 1fr); }
+  .blog-grid{ grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 @media (min-width: 768px){
   .about-grid{ grid-template-columns: 1.05fr 0.95fr; }
@@ -214,6 +331,7 @@ img{ max-width:100%; display:block; }
 }
 @media (min-width: 1024px){
   .cards{ grid-template-columns: repeat(3, 1fr); }
+  .blog-grid{ grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 
 /* Punto móvil principal */

--- a/src/app/Components/Home/Home.tsx
+++ b/src/app/Components/Home/Home.tsx
@@ -89,6 +89,42 @@ export default function Home() {
                   },
                 },
               },
+              {
+                "@type": "Blog",
+                "@id": "https://www.myl3d.es/#blog",
+                name: "Blog y recursos MyL3d",
+                url: "https://www.myl3d.es/blog",
+                description:
+                  "Ideas, buenas prácticas y casos de éxito sobre pantallas LED, eventos híbridos y cartelería digital en España.",
+                inLanguage: "es-ES",
+                isPartOf: { "@id": "https://www.myl3d.es/#webpage" },
+                blogPost: [
+                  {
+                    "@type": "BlogPosting",
+                    headline: "Cómo planificar un evento híbrido con éxito",
+                    url: "https://www.myl3d.es/blog/eventos-hibridos",
+                    datePublished: "2024-03-12",
+                    inLanguage: "es-ES",
+                    timeRequired: "PT6M",
+                  },
+                  {
+                    "@type": "BlogPosting",
+                    headline: "Pantallas LED vs. LCD: cuál es la mejor opción para tu espacio comercial",
+                    url: "https://www.myl3d.es/blog/pantallas-led-vs-lcd",
+                    datePublished: "2024-02-26",
+                    inLanguage: "es-ES",
+                    timeRequired: "PT5M",
+                  },
+                  {
+                    "@type": "BlogPosting",
+                    headline: "Caso de éxito: experiencia inmersiva en museo interactivo",
+                    url: "https://www.myl3d.es/blog/caso-exito-museo-inmersivo",
+                    datePublished: "2024-01-30",
+                    inLanguage: "es-ES",
+                    timeRequired: "PT7M",
+                  },
+                ],
+              },
             ],
           }),
         }}
@@ -279,6 +315,113 @@ export default function Home() {
           >
             ¿Necesitas asesoramiento? <Link href="/contacto">Contacta con nuestro equipo</Link> para recibir un presupuesto personalizado y descubrir cómo potenciar tu próxima acción con audiovisuales profesionales.
           </motion.p>
+        </div>
+      </section>
+
+      <section id="blog" className="section">
+        <div className="container">
+          <motion.h2
+            className="section__title"
+            variants={item}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.2 }}
+          >
+            Blog y recursos
+          </motion.h2>
+          <motion.p
+            className="section__copy section__copy--muted"
+            variants={item}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.2 }}
+          >
+            Explora guías prácticas, tendencias y casos de éxito sobre cartelería digital, producción audiovisual y pantallas LED
+            para inspirar tu próximo proyecto.
+          </motion.p>
+
+          <div className="blog-grid" role="list">
+            {[
+              {
+                title: "Cómo planificar un evento híbrido con éxito",
+                description:
+                  "Checklist técnico y recomendaciones para combinar asistentes presenciales y online sin perder calidad.",
+                href: "/blog/eventos-hibridos",
+                category: "Eventos corporativos",
+                readTime: "6 min de lectura",
+                date: "2024-03-12",
+              },
+              {
+                title: "Pantallas LED vs. LCD: cuál es la mejor opción para tu espacio comercial",
+                description:
+                  "Comparamos tecnologías, costes y mantenimiento para ayudarte a elegir la solución de digital signage adecuada.",
+                href: "/blog/pantallas-led-vs-lcd",
+                category: "Cartelería digital",
+                readTime: "5 min de lectura",
+                date: "2024-02-26",
+              },
+              {
+                title: "Caso de éxito: experiencia inmersiva en museo interactivo",
+                description:
+                  "Descubre cómo integramos sonido 3D, mapping y pantallas de gran formato para transformar la visita del público.",
+                href: "/blog/caso-exito-museo-inmersivo",
+                category: "Cultura y ocio",
+                readTime: "7 min de lectura",
+                date: "2024-01-30",
+              },
+            ].map((post, index) => (
+              <Link key={post.href} href={post.href} className="blog-card" role="listitem">
+                <motion.article
+                  initial={{ opacity: 0, y: 18 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.5, delay: 0.1 * index }}
+                  viewport={{ once: true, amount: 0.2 }}
+                >
+                  <div className="blog-card__meta">
+                    <span className="blog-card__badge">{post.category}</span>
+                    <time dateTime={post.date}>{post.readTime}</time>
+                  </div>
+                  <h3 className="blog-card__title">{post.title}</h3>
+                  <p className="blog-card__excerpt">{post.description}</p>
+                  <span className="blog-card__cta">
+                    Leer artículo
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                      <path
+                        d="M13.5 5l6 6-6 6"
+                        stroke="currentColor"
+                        strokeWidth="1.8"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                      <path
+                        d="M5.5 11h12"
+                        stroke="currentColor"
+                        strokeWidth="1.8"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  </span>
+                </motion.article>
+              </Link>
+            ))}
+          </div>
+
+          <motion.div
+            className="blog-more"
+            variants={item}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.2 }}
+          >
+            <Link href="/blog" className="blog-more__link">
+              Ver todos los recursos
+              <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13.5 5l6 6-6 6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M5.5 11h12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </Link>
+          </motion.div>
         </div>
       </section>
     </>

--- a/src/app/Components/site-header/Siteheader.tsx
+++ b/src/app/Components/site-header/Siteheader.tsx
@@ -31,9 +31,10 @@ export default function SiteHeader({
         { href: "/servicios/salas-de-control", label: "Salas de control" },
       ],
     },
+    { href: "/#blog", label: "Blog y recursos" },
 
     { href: "/contacto", label: "Contacto" }, // ✅ ruta real
-        
+
   ],
   className = "",
 }: SiteHeaderProps) {

--- a/src/app/blog/blog.css
+++ b/src/app/blog/blog.css
@@ -1,0 +1,262 @@
+.blog {
+  background: radial-gradient(circle at top left, rgba(48, 1, 202, 0.35), transparent 45%), #020617;
+  color: #e2e8f0;
+  padding-top: 72px;
+}
+
+.blog__hero {
+  padding: clamp(4rem, 12vw, 7rem) 0 3rem;
+}
+
+.blog__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  color: #c7d2fe;
+  font-weight: 600;
+  letter-spacing: 0.1rem;
+  text-transform: uppercase;
+}
+
+.blog__title {
+  margin: 1.25rem 0 1rem;
+  font-size: clamp(2.1rem, 5vw, 3.2rem);
+  line-height: 1.15;
+  color: #f8fafc;
+  max-width: 16ch;
+}
+
+.blog__lead {
+  margin: 0;
+  max-width: 60ch;
+  font-size: clamp(1.05rem, 1.5vw, 1.2rem);
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.blog__cta {
+  margin-top: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.blog__cta-link,
+.blog__cta-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.18s ease, background-color 0.18s ease, color 0.18s ease;
+}
+
+.blog__cta-link {
+  background: #3b00ff;
+  color: #ffffff;
+}
+
+.blog__cta-link:hover {
+  transform: translateY(-2px);
+  background: #ffffff;
+  color: #3b00ff;
+}
+
+.blog__cta-secondary {
+  background: rgba(99, 102, 241, 0.1);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: rgba(226, 232, 240, 0.86);
+}
+
+.blog__cta-secondary:hover {
+  transform: translateY(-2px);
+  background: rgba(99, 102, 241, 0.18);
+}
+
+.blog__listing {
+  padding: 3rem 0 4rem;
+}
+
+.blog__listing-header {
+  max-width: 720px;
+  margin-bottom: 2.2rem;
+}
+
+.blog__listing-header h2 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  color: #f8fafc;
+}
+
+.blog__listing-header p {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(226, 232, 240, 0.78);
+  line-height: 1.65;
+}
+
+.blog__grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.blog__card {
+  display: block;
+  padding: 1.75rem;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease;
+}
+
+.blog__card article {
+  display: grid;
+  gap: 1rem;
+}
+
+.blog__card-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.blog__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.18);
+  color: #c7d2fe;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.15px;
+  text-transform: uppercase;
+}
+
+.blog__card h3 {
+  margin: 0;
+  font-size: clamp(1.35rem, 2.4vw, 1.7rem);
+  color: #f8fafc;
+  line-height: 1.3;
+}
+
+.blog__card p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.78);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.blog__card-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #c7d2fe;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+}
+
+.blog__card-cta svg {
+  transition: transform 0.18s ease;
+}
+
+.blog__card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 25px 45px -30px rgba(15, 23, 42, 0.9);
+  border-color: rgba(99, 102, 241, 0.6);
+}
+
+.blog__card:hover .blog__card-cta svg {
+  transform: translateX(4px);
+}
+
+.blog__cta-banner {
+  padding: 4rem 0 5rem;
+}
+
+.blog__cta-banner .container {
+  display: grid;
+  gap: 1.5rem;
+  background: linear-gradient(135deg, rgba(59, 0, 255, 0.85), rgba(15, 23, 42, 0.95));
+  border-radius: 22px;
+  padding: 2.5rem clamp(1.5rem, 4vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.blog__cta-banner-content h2 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.7rem, 3vw, 2.3rem);
+  color: #ffffff;
+}
+
+.blog__cta-banner-content p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.88);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.blog__cta-banner-link {
+  align-self: center;
+  justify-self: start;
+  padding: 0.9rem 1.6rem;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #3b00ff;
+  font-weight: 700;
+  text-decoration: none;
+  transition: transform 0.18s ease, background 0.18s ease, color 0.18s ease;
+}
+
+.blog__cta-banner-link:hover {
+  transform: translateY(-2px);
+  background: #3b00ff;
+  color: #ffffff;
+}
+
+@media (min-width: 640px) {
+  .blog__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .blog__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .blog__cta-banner .container {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+  }
+}
+
+@media (max-width: 900px) {
+  .blog {
+    padding-top: 68px;
+  }
+
+  .blog__hero {
+    padding: 4rem 0 2rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blog__cta-link,
+  .blog__cta-secondary,
+  .blog__card,
+  .blog__card-cta svg,
+  .blog__cta-banner-link {
+    transition: none !important;
+  }
+}
+

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,230 @@
+import Script from "next/script";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import type { Metadata } from "next";
+import SiteHeader from "@/app/Components/site-header/Siteheader";
+
+import "./blog.css";
+
+const servicesChildren = [
+  { href: "/servicios/Carteleria-digital", label: "Carteleria digital" },
+  { href: "/servicios/cultura-y-ocio", label: "Cultura y ocio" },
+  { href: "/servicios/eventos", label: "Eventos" },
+  { href: "/servicios/corporativos", label: "Corporativos" },
+  { href: "/servicios/educacion", label: "Educación" },
+  { href: "/servicios/salas-de-control", label: "Salas de control" },
+];
+
+const posts = [
+  {
+    title: "Cómo planificar un evento híbrido con éxito",
+    description:
+      "Checklist técnico, guion y recomendaciones logísticas para ofrecer una experiencia fluida a asistentes presenciales y online.",
+    href: "/blog/eventos-hibridos",
+    category: "Eventos corporativos",
+    readTime: "6 min de lectura",
+    date: "2024-03-12",
+    excerpt:
+      "Analizamos los elementos esenciales para sincronizar producción audiovisual, streaming y participación de la audiencia en eventos híbridos de gran escala.",
+  },
+  {
+    title: "Pantallas LED vs. LCD: cuál es la mejor opción para tu espacio comercial",
+    description:
+      "Comparamos tecnologías, costes operativos y mantenimiento para ayudarte a escoger la solución de digital signage que mejor encaja con tu negocio.",
+    href: "/blog/pantallas-led-vs-lcd",
+    category: "Cartelería digital",
+    readTime: "5 min de lectura",
+    date: "2024-02-26",
+    excerpt:
+      "Te explicamos cuándo apostar por paneles LED, qué ventajas ofrecen frente a LCD y cómo calcular el retorno de inversión de tu circuito de pantallas.",
+  },
+  {
+    title: "Caso de éxito: experiencia inmersiva en museo interactivo",
+    description:
+      "Descubre cómo integramos pantallas LED de gran formato, sonido 3D y contenidos interactivos para transformar la visita del público en un museo tecnológico.",
+    href: "/blog/caso-exito-museo-inmersivo",
+    category: "Cultura y ocio",
+    readTime: "7 min de lectura",
+    date: "2024-01-30",
+    excerpt:
+      "Repasamos los hitos técnicos del proyecto, desde la ingeniería audiovisual hasta la creación de contenidos inmersivos que aumentaron el tiempo de permanencia en sala.",
+  },
+  {
+    title: "Guía rápida para implantar cartelería digital en retail",
+    description:
+      "Pasos clave para definir objetivos, elegir hardware y establecer un plan de contenidos que incremente las ventas en tienda.",
+    href: "/blog/guia-carteleria-digital-retail",
+    category: "Retail",
+    readTime: "8 min de lectura",
+    date: "2023-12-12",
+    excerpt:
+      "Incluimos checklist de despliegue, recomendaciones de tamaños de pantalla según superficie y métricas para evaluar el éxito de la instalación.",
+  },
+  {
+    title: "Cómo producir contenido 3D para pantallas LED gigantes",
+    description:
+      "Buenas prácticas para desarrollar visuales volumétricos que aprovechen la profundidad de las pantallas LED de última generación.",
+    href: "/blog/contenido-3d-pantallas-led",
+    category: "Producción audiovisual",
+    readTime: "9 min de lectura",
+    date: "2023-11-03",
+    excerpt:
+      "Revisamos herramientas, pipeline creativo y recomendaciones técnicas para evitar distorsiones y optimizar tiempos de render.",
+  },
+  {
+    title: "Checklist técnico para ferias y congresos con pantallas LED",
+    description:
+      "Todo lo que debes revisar antes de abrir puertas: estructura, electricidad, redundancia de señal y planes de contingencia.",
+    href: "/blog/checklist-pantallas-led-ferias",
+    category: "Eventos",
+    readTime: "6 min de lectura",
+    date: "2023-09-14",
+    excerpt:
+      "Compartimos la metodología que emplea MyL3d para asegurar despliegues fiables en entornos de alto tráfico y montajes express.",
+  },
+];
+
+export const metadata: Metadata = {
+  title: "Blog y recursos audiovisuales | MyL3d",
+  description:
+    "Ideas, guías y casos de éxito sobre cartelería digital, pantallas LED y producción audiovisual para eventos corporativos, retail y cultura en España.",
+  alternates: {
+    canonical: "https://www.myl3d.es/blog",
+  },
+  openGraph: {
+    title: "Blog y recursos audiovisuales | MyL3d",
+    description:
+      "Explora buenas prácticas, tendencias y casos reales de proyectos audiovisuales con pantallas LED, streaming y contenidos inmersivos.",
+    url: "https://www.myl3d.es/blog",
+    type: "website",
+    locale: "es_ES",
+    siteName: "MyL3d",
+  },
+};
+
+export default function BlogPage() {
+  return (
+    <>
+      <Script
+        id="blog-structured-data"
+        type="application/ld+json"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Blog",
+            name: "Blog y recursos MyL3d",
+            url: "https://www.myl3d.es/blog",
+            description:
+              "Guías, tendencias y casos prácticos sobre pantallas LED, cartelería digital y producción audiovisual profesional en España.",
+            inLanguage: "es-ES",
+            publisher: {
+              "@type": "Organization",
+              name: "MyL3d",
+              url: "https://www.myl3d.es",
+            },
+            blogPost: posts.map((post) => ({
+              "@type": "BlogPosting",
+              headline: post.title,
+              url: `https://www.myl3d.es${post.href}`,
+              datePublished: post.date,
+              description: post.description,
+              inLanguage: "es-ES",
+            })),
+          }),
+        }}
+      />
+
+      <SiteHeader
+        links={[
+          { href: "/", label: "Inicio" },
+          { label: "Servicios", children: servicesChildren },
+          { href: "/blog", label: "Blog y recursos", ariaCurrent: "page" },
+          { href: "/contacto", label: "Contacto" },
+        ]}
+      />
+
+      <main className="blog">
+        <section className="blog__hero">
+          <div className="container">
+            <motion.span className="blog__eyebrow" initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }}>
+              Blog y recursos
+            </motion.span>
+            <motion.h1
+              className="blog__title"
+              initial={{ opacity: 0, y: 14 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
+            >
+              Ideas, guías y casos reales para potenciar tus proyectos audiovisuales
+            </motion.h1>
+            <motion.p
+              className="blog__lead"
+              initial={{ opacity: 0, y: 14 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.1 }}
+            >
+              Seleccionamos contenidos con recomendaciones prácticas sobre cartelería digital, eventos híbridos, espacios culturales y producción audiovisual inmersiva.
+            </motion.p>
+            <motion.div className="blog__cta" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.25 }}>
+              <Link className="blog__cta-link" href="#articulos">
+                Ver artículos destacados
+              </Link>
+              <Link className="blog__cta-secondary" href="/contacto">
+                Solicitar asesoramiento
+              </Link>
+            </motion.div>
+          </div>
+        </section>
+
+        <section id="articulos" className="blog__listing">
+          <div className="container">
+            <div className="blog__listing-header">
+              <h2>Artículos destacados</h2>
+              <p>
+                Desde la planificación técnica hasta la creación de contenidos, aquí encontrarás guías accionables que te ayudan a sacar el máximo partido a la tecnología audiovisual.
+              </p>
+            </div>
+
+            <div className="blog__grid" role="list">
+              {posts.map((post) => (
+                <Link key={post.href} href={post.href} className="blog__card" role="listitem">
+                  <article>
+                    <div className="blog__card-meta">
+                      <span className="blog__badge">{post.category}</span>
+                      <time dateTime={post.date}>{post.readTime}</time>
+                    </div>
+                    <h3>{post.title}</h3>
+                    <p>{post.excerpt}</p>
+                    <span className="blog__card-cta">
+                      Leer artículo
+                      <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M13.5 5l6 6-6 6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                        <path d="M5.5 11h12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </span>
+                  </article>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="blog__cta-banner">
+          <div className="container">
+            <div className="blog__cta-banner-content">
+              <h2>¿Quieres lanzar un proyecto audiovisual?</h2>
+              <p>
+                Nuestro equipo puede ayudarte a definir la tecnología adecuada, producir el contenido y coordinar la ejecución en ferias, museos o espacios corporativos.
+              </p>
+            </div>
+            <Link href="/contacto" className="blog__cta-banner-link">
+              Contacta con MyL3d
+            </Link>
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a "Blog y recursos" link to the site header and extend the home section with a button to view more articles
- create a dedicated blog landing page with structured data, featured articles and calls to action
- style the blog listing page to match the existing visual language and remain responsive across breakpoints

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ffb772586c8326aecdaa6221898cd6