### PR TITLE
Add productos landing with filterable grid

### DIFF
--- a/src/app/Components/productos/productos.css
+++ b/src/app/Components/productos/productos.css
@@ -1,0 +1,225 @@
+.productos-page {
+  background: #020617;
+  color: #e2e8f0;
+}
+
+.products-hero {
+  position: relative;
+  padding: clamp(6rem, 12vw, 9rem) 0 clamp(4rem, 8vw, 6rem);
+  background: linear-gradient(140deg, rgba(16, 24, 40, 0.85) 0%, rgba(15, 23, 42, 0.9) 55%, rgba(48, 1, 202, 0.6) 100%),
+    url("/pantallas.png") center/cover no-repeat;
+  overflow: hidden;
+}
+
+.products-hero__overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(2, 6, 23, 0.85) 10%, rgba(15, 23, 42, 0.75) 55%, rgba(48, 1, 202, 0.65) 100%);
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
+
+.products-hero__content {
+  position: relative;
+  z-index: 1;
+  max-width: 760px;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.products-hero__eyebrow {
+  font-size: 0.95rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.products-hero__title {
+  margin: 0;
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  font-weight: 800;
+  color: #fff;
+  line-height: 1.1;
+}
+
+.products-hero__subtitle {
+  margin: 0;
+  font-size: clamp(1.05rem, 1.6vw, 1.35rem);
+  color: rgba(226, 232, 240, 0.86);
+  max-width: 52ch;
+}
+
+.products-section {
+  position: relative;
+  isolation: isolate;
+}
+
+.products-section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.products-section__copy {
+  margin: 0;
+  color: #0f172a;
+  max-width: 62ch;
+}
+
+.products-section__cta {
+  white-space: nowrap;
+  background: var(--brand);
+  border: none;
+  box-shadow: 0 16px 30px -18px rgba(48, 1, 202, 0.6);
+}
+
+.products-section__cta:hover {
+  color: var(--brand);
+}
+
+.product-filters {
+  margin: 2.5rem 0 1.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.product-filters__button {
+  border: 1px solid rgba(48, 1, 202, 0.25);
+  background: #fff;
+  color: #1e293b;
+  font-weight: 600;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.product-filters__button:hover {
+  border-color: rgba(48, 1, 202, 0.5);
+  color: var(--brand);
+}
+
+.product-filters__button.is-active {
+  background: var(--brand);
+  color: #fff;
+  border-color: var(--brand);
+  box-shadow: 0 12px 30px -18px rgba(48, 1, 202, 0.8);
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+.product-card {
+  display: grid;
+  grid-template-rows: minmax(220px, 1fr) auto;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 18px;
+  overflow: hidden;
+  background: #fff;
+  color: #0f172a;
+  box-shadow: 0 22px 40px -28px rgba(15, 23, 42, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.product-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 28px 60px -30px rgba(15, 23, 42, 0.4);
+}
+
+.product-card__media {
+  position: relative;
+  min-height: 240px;
+  background: #0f172a;
+}
+
+.product-card__image {
+  object-fit: cover;
+}
+
+.product-card__body {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1.6rem;
+}
+
+.product-card__category {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--brand);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.product-card__title {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.product-card__description {
+  margin: 0;
+  color: #1e293b;
+  line-height: 1.55;
+}
+
+.product-card__specs {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+  color: #334155;
+}
+
+.product-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.product-card__price {
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.product-card__link {
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--brand);
+  transition: color 0.2s ease;
+}
+
+.product-card__link:hover {
+  color: #220486;
+}
+
+@media (min-width: 700px) {
+  .products-section__header {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .product-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1100px) {
+  .products-hero {
+    padding-block: clamp(7rem, 10vw, 10rem);
+  }
+
+  .product-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/src/app/Components/productos/productos.tsx
+++ b/src/app/Components/productos/productos.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import "./productos.css";
+
+type Product = {
+  name: string;
+  category: string;
+  description: string;
+  image: string;
+  alt: string;
+  price: string;
+  specs: string[];
+};
+
+type Filter = {
+  label: string;
+  value: string;
+};
+
+const filters: Filter[] = [
+  { label: "Todos", value: "Todos" },
+  { label: "Pantallas LED", value: "Pantallas LED" },
+  { label: "Tótems digitales", value: "Tótems digitales" },
+  { label: "Procesadores", value: "Procesadores" },
+  { label: "Soportes", value: "Soportes" },
+];
+
+const products: Product[] = [
+  {
+    name: "Panel modular LED P1.9 UHD",
+    category: "Pantallas LED",
+    description:
+      "Módulos de alta densidad diseñados para estudios y espacios premium donde la nitidez y la reproducción cromática son clave.",
+    image: "/res/videwall.webp",
+    alt: "Video wall LED de alta resolución instalado en showroom",
+    price: "Desde 385 € / m²",
+    specs: ["Pitch 1.9 mm", "Brillo 1.800 nits", "Calibración HDR10"],
+  },
+  {
+    name: "Panel LED exterior P3.9",
+    category: "Pantallas LED",
+    description:
+      "Chasis ligero y sellado IP65 ideal para giras, festivales y fachadas. Sistema de bloqueo rápido para montaje ágil.",
+    image: "/res/stand.png",
+    alt: "Escenario exterior con paneles LED modulares",
+    price: "Desde 340 € / m²",
+    specs: ["Pitch 3.9 mm", "Brillo 4.500 nits", "Curvatura ±10°"],
+  },
+  {
+    name: "Tótem digital doble cara",
+    category: "Tótems digitales",
+    description:
+      "Estructura autoportante con players sincronizados para retail, hoteles y recepción corporativa.",
+    image: "/res/totems.png",
+    alt: "Tótems digitales en lobby corporativo",
+    price: "Desde 189 € / unidad",
+    specs: ["Pantalla 55\" UHD", "Reproductor 4K integrado", "Cristal templado antivandálico"],
+  },
+  {
+    name: "Procesador NovaStar VX600",
+    category: "Procesadores",
+    description:
+      "Controlador híbrido con escalado profesional, redundancia HDMI/DP y preset de escenas para directos.",
+    image: "/res/interior-totem.png",
+    alt: "Procesador de vídeo NovaStar instalado en rack",
+    price: "Desde 1.890 €",
+    specs: ["Entrada 4K", "Hasta 6 salidas", "Edición en vivo"],
+  },
+  {
+    name: "Estructura truss y soporte modular",
+    category: "Soportes",
+    description:
+      "Solución modular en aluminio para colgado o apilado de pantallas LED con certificación europea.",
+    image: "/res/stand-ise.png",
+    alt: "Estructura truss soportando pantalla LED en feria",
+    price: "Bajo pedido",
+    specs: ["Carga hasta 1.000 kg", "Configuración personalizada", "Incluye ingeniería y montaje"],
+  },
+];
+
+export default function Productos() {
+  const [activeFilter, setActiveFilter] = useState<string>(filters[0]?.value ?? "Todos");
+
+  const visibleProducts = useMemo(() => {
+    if (activeFilter === "Todos") {
+      return products;
+    }
+
+    return products.filter((product) => product.category === activeFilter);
+  }, [activeFilter]);
+
+  return (
+    <div className="productos-page">
+      <section className="products-hero" aria-labelledby="products-title">
+        <div className="products-hero__overlay" aria-hidden />
+        <div className="container products-hero__content">
+          <p className="products-hero__eyebrow">Catálogo especializado</p>
+          <h1 id="products-title" className="products-hero__title">
+            Soluciones LED profesionales para cada proyecto
+          </h1>
+          <p className="products-hero__subtitle">
+            Selección de módulos, tótems y sistemas de control listos para integrar en instalaciones fijas o eventos en directo.
+          </p>
+        </div>
+      </section>
+
+      <section className="section section--alt products-section" aria-labelledby="products-section-title">
+        <div className="container">
+          <header className="products-section__header">
+            <div>
+              <h2 id="products-section-title" className="section__title">
+                Nuestros productos destacados
+              </h2>
+              <p className="products-section__copy">
+                Trabajamos con equipamiento certificado y soporte técnico para garantizar un rendimiento óptimo tanto en interior
+                como exterior.
+              </p>
+            </div>
+            <Link className="btn-cta products-section__cta" href="/contacto">
+              Solicita asesoramiento
+            </Link>
+          </header>
+
+          <div className="product-filters" role="tablist" aria-label="Categorías de productos">
+            {filters.map((filter) => (
+              <button
+                key={filter.value}
+                type="button"
+                className={`product-filters__button${activeFilter === filter.value ? " is-active" : ""}`}
+                role="tab"
+                aria-selected={activeFilter === filter.value}
+                onClick={() => setActiveFilter(filter.value)}
+              >
+                {filter.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="product-grid">
+            {visibleProducts.map((product) => (
+              <article key={product.name} className="product-card">
+                <div className="product-card__media">
+                  <Image
+                    src={product.image}
+                    alt={product.alt}
+                    fill
+                    sizes="(min-width: 1200px) 25vw, (min-width: 900px) 30vw, 90vw"
+                    priority={product.name === visibleProducts[0]?.name}
+                    className="product-card__image"
+                  />
+                </div>
+                <div className="product-card__body">
+                  <span className="product-card__category">{product.category}</span>
+                  <h3 className="product-card__title">{product.name}</h3>
+                  <p className="product-card__description">{product.description}</p>
+                  <ul className="product-card__specs">
+                    {product.specs.map((spec) => (
+                      <li key={spec}>{spec}</li>
+                    ))}
+                  </ul>
+                  <div className="product-card__footer">
+                    <span className="product-card__price">{product.price}</span>
+                    <Link className="product-card__link" href="/contacto">
+                      Solicitar presupuesto
+                    </Link>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/Components/site-header/Siteheader.tsx
+++ b/src/app/Components/site-header/Siteheader.tsx
@@ -31,6 +31,7 @@ export default function SiteHeader({
         { href: "/servicios/salas-de-control", label: "Salas de control" },
       ],
     },
+    { href: "/productos", label: "Productos" },
     { href: "/#blog", label: "Blog y recursos" },
 
     { href: "/contacto", label: "Contacto" }, // ✅ ruta real

--- a/src/app/productos/page.tsx
+++ b/src/app/productos/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import SiteHeader from "../Components/site-header/Siteheader";
+import Productos from "../Components/productos/productos";
+
+export const metadata: Metadata = {
+  title: "Productos audiovisuales profesionales | MyL3d",
+  description:
+    "Catálogo de pantallas LED, tótems digitales, procesadores de vídeo y estructuras para integrar en proyectos corporativos y eventos.",
+  alternates: { canonical: "/productos" },
+  openGraph: {
+    title: "Productos audiovisuales profesionales | MyL3d",
+    description:
+      "Soluciones LED modulares, soportes y controladores con soporte técnico especializado en toda España.",
+    url: "https://www.myl3d.es/productos",
+    type: "website",
+  },
+};
+
+export default function ProductosPage() {
+  return (
+    <>
+      <SiteHeader />
+      <Productos />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add the Productos item to the main navigation
- create the /productos page with hero content and product data
- style the new product grid to match the existing brand system

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6908c28997b083269f938322a705ffa9